### PR TITLE
Fix illegal option bug

### DIFF
--- a/llama.sh
+++ b/llama.sh
@@ -46,7 +46,7 @@ parse_event() {
 parse_event_stream() {
 	while IFS= read -r LINE; do
 		printr "$LINE" | grep -q "data:*" &&
-			printf "$(parse_event "$LINE")"
+			printf "%b" "$(parse_event "$LINE")"
 	done
 }
 


### PR DESCRIPTION
Asking `llama.sh` for Linux commands results in the following bug when it outputs "-": 
<img width="595" alt="img" src="https://github.com/m18coppola/llama.sh/assets/6587642/5388ba39-57b9-48a7-affa-7a49ac0e8327">
